### PR TITLE
Propose a simple docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+# Simple base dockerfile to simplify its usage without need to have node locally.
+FROM node:alpine
+
+RUN npm install -g svg-term-cli
+
+ENTRYPOINT [ "svg-term" ]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ Generate the `parrot.svg` example from [asciicast](https://asciinema.org/a/11364
 svg-term --cast=113643 --out examples/parrot.svg --window
 ```
 
+### Docker
+
+Skip the node installation running with docker:
+
+```sh
+docker run --rm marionebl/svg-term --cast=113643 --window >> examples/parrot.svg
+# Run with --interactive(-i) to keep STDIN open
+cat rec.json | docker run --rm -i marionebl/svg-term >> examples/parrot.svg
+# Map volumes to have a better log if any error
+docker run --rm -v $PWD:/data marionebl/svg-term --cast=113643 --out /data/parrot.svg --window
+```
+
 ## Interface
 
 ```


### PR DESCRIPTION
Wrap the tool inside the docker to let its simple use without the need to install node in the environment. It could sound useless for some folks, but imagine if you need to handle a ruby, java, etc. tools? Some will prefer to keep the environment clean. Docker will give this easy solution.

Follow the instructions to automate the docker image publishing: https://docs.docker.com/docker-hub/builds/
Example of build: https://cloud.docker.com/repository/registry-1.docker.io/voiski/svg-term-cli/builds/187f1043-9cfd-4961-9e12-101667e6b512

> Please let me know if I should remove that image, I did more for demonstration and test.